### PR TITLE
Update field names in Feature, L3BaseConfig, and ProviderBgpConfig schemas to improve clarity and consistency.

### DIFF
--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -1879,8 +1879,8 @@
             "description": "Identifier. A unique identifier for the feature resource.",
             "type": "string"
           },
-          "channelId": {
-            "description": "A unique identifier for the channel this feature is associated with.",
+          "channel": {
+            "description": "Required. The URI of the channel this feature is associated with.\n\nEach feature is only associated with a single channel and the channel must\nexist. Each connection resource will have a child feature for each channel\nthat is a child of the parent interconnect resource. For example a\nconnection that is a child of an interconnect with 4 channels will have 4\nchild features, each associated with a different channel.",
             "type": "string"
           },
           "featureConfig": {
@@ -1920,36 +1920,36 @@
         "description": "All FEATURE_TYPE_L3_BASE configuration.",
         "type": "object",
         "properties": {
-          "ipSubnetV4": {
-            "description": "IPv4 subnet used to establish L3 connectivity for the customer\n\nNote: The IP address must have the subnet mask applied to it.",
+          "ipv4Subnet": {
+            "description": "Required. IPv4 subnet used to establish L3 connectivity for the customer\n\nNote: The IP address must have the subnet mask applied to it.",
             "type": "string"
           },
-          "subnetSizeV4": {
-            "description": "IPv4 subnet size.",
+          "ipv4SubnetPrefixLength": {
+            "description": "Required. IPv4 subnet prefix length.",
             "type": "integer",
             "format": "int32"
           },
-          "ipSubnetV6": {
-            "description": "IPv6 subnet used to establish L3 connectivity for the customer\n\nNote: The IP address must have the subnet mask applied to it.",
+          "ipv6Subnet": {
+            "description": "Optional. IPv6 subnet used to establish L3 connectivity for the customer\n\nNote: The IP address must have the subnet mask applied to it.",
             "type": "string"
           },
-          "subnetSizeV6": {
-            "description": "IPv6 subnet size.",
+          "ipv6SubnetPrefixLength": {
+            "description": "Optional. IPv6 subnet prefix length.",
             "type": "integer",
             "format": "int32"
           },
-          "mtu": {
-            "description": "MTU limit for VLAN attachments.\n\nSpecial note: This represents the MTU limits at the connection points\nbetween providers, there may be further limitations within provider\nnetworks that must be explained in customer facing APIs and / or\ndocumentation.",
+          "mtuBytes": {
+            "description": "Required. MTU for VLAN attachments.\n\nSpecial note: This represents the MTU at the connection points\nbetween providers, there may be further MTU limitations within provider\nnetworks.",
             "type": "integer",
             "format": "int32"
           },
-          "vlan": {
-            "description": "VLAN ID used by the connection.\n\nVLAN 1024 and lower are reserved and cannot have features associated with\nthem.  Otherwise, a provider may select from any available VLANs.",
+          "vlanId": {
+            "description": "Required. VLAN ID used by the connection.\n\nVLAN 1024 and lower are reserved and cannot have features associated with\nthem.  Otherwise, a provider may select from any available VLANs.",
             "type": "integer",
             "format": "int32"
           },
-          "sessionAttr": {
-            "description": "A mapping of provider ID to all BGP session attributes the provider\nshould use.",
+          "providerBgpConfigs": {
+            "description": "Required. A mapping of provider ID to all BGP session attributes the provider\nshould use.",
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ProviderBgpConfig"
@@ -1965,21 +1965,21 @@
         "description": "All parameters needed for a provider to configure a BGP session\nassociated with a channel.",
         "type": "object",
         "properties": {
-          "providerId": {
-            "description": "A unique id that associates this BGP configuration with a specific\nprovider.",
+          "provider": {
+            "description": "Required. The resource name of the provider that this BGP configuration is\nassociated with.",
             "type": "string"
           },
           "asn": {
-            "description": "The ASN associated with the provider.",
+            "description": "Required. The ASN associated with the provider.",
             "type": "integer",
             "format": "int32"
           },
           "hostIpv4": {
-            "description": "IPv4 address hosting BGP session for provider.",
+            "description": "Required. IPv4 address hosting BGP session for provider.",
             "type": "string"
           },
           "hostIpv6": {
-            "description": "IPv6 address hosting BGP session for provider.",
+            "description": "Optional. IPv6 address hosting BGP session for provider.",
             "type": "string"
           }
         }


### PR DESCRIPTION
Update field names in Feature, L3BaseConfig, and ProviderBgpConfig schemas to improve clarity and consistency.

The following fields have been renamed:

- channelId is now channel (since URI not ID will be used)
- ipSubnetV4 is now ipv4Subnet (Consistent prefix and more standard)
- subnetSizeV4 is now ipv4SubnetPrefixLength (Consistent prefix and more standard)
- ipSubnetV6 is now ipv6Subnet (Consistent prefix and more standard)
- subnetSizeV6 is now ipv6SubnetPrefixLength (Consistent prefix and more standard)
- mtu is now mtuBytes (add unit)
- vlan is now vlanId (since this is an ID)
- sessionAttr is now providerBgpConfigs (it was a list of providerBgpConfig so why not use that.
- providerId is now provider (URI not ID)

Field descriptions have also been updated to explicitly state whether they are Required or Optional.
