### PR TITLE
Update ActivationKey version to use "integer" instead of "int" to pass schema validation

### DIFF
--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -1456,7 +1456,8 @@
         "properties": {
           "version": {
             "description": "Required. Version of the ActivationKey itself. The version should\nmatch the API version on the creating service.",
-            "type": "int"
+            "type": "integer",
+            "format": "int32"
           },
           "destinationEnvironmentUri": {
             "description": "Required. The destination environment URI this activation key is\nintended for use at.",


### PR DESCRIPTION
int is not a valid type in OpenAPI per our internal parser so it is not letting me pull in the changes so I can update our proto. This fixes the type.
