### PR TITLE
Explicit EncodedActivationKey Type and ASN Integer Type Changes.

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -1946,11 +1946,11 @@ components:
       properties:
         start:
           description: First ASN (inclusive).
-          format: int32
+          format: uint32
           type: integer
         stop:
           description: Last ASN (inclusive).
-          format: int32
+          format: uint32
           type: integer
       type: object
     SubnetGuidance:
@@ -2120,7 +2120,7 @@ components:
           type: string
         asn:
           description: Required. The ASN associated with the provider.
-          format: int32
+          format: uint32
           type: integer
         hostIpv4:
           description: Required. IPv4 address hosting BGP session for provider.

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -1387,9 +1387,14 @@ components:
       properties:
         key:
           allOf:
-          - $ref: "#/components/schemas/ActivationKey"
+          - $ref: "#/components/schemas/EncodedActivationKey"
           description: Activation key to be confirmed.
       type: object
+    EncodedActivationKey:
+      description: |-
+        An ActivationKey, encoded in whichever scheme is defined by the protocol
+        version. For V1, the ActivationKey is Base64 encoded.
+      type: string
     ActivationKey:
       description: |-
         Activation Keys contain all information needed by a provider to validate a
@@ -1397,7 +1402,7 @@ components:
 
         The activation key should be base64 encoded whenever it is exchanged between
         providers.  This helps prevent accidental corruption of the key when
-        transferring it between clouds.
+        transferring it between clouds. (See "#/components/schemas/EncodedActivationKey")
       properties:
         version:
           description: |-
@@ -1746,7 +1751,7 @@ components:
           type: string
         activationKey:
           description: Identifier. A activation key associated with the connection.
-          type: string
+          $ref: "#/components/schemas/EncodedActivationKey"
         bandwidthMbps:
           description: |-
             The total bandwidth associated with a connection.  This bandwidth is what


### PR DESCRIPTION
Update the type for all ASNs to be uint32 rather than int32.

Also added a new type for EncodedActivationKey to be explicit about when Base64 should be used.  The existing ActivationKey type is strictly used to describe the key itself.

The isolated nature of the key and it's separate version field make it a good candidate for a separate YAML file.