### PR TITLE
Fix $ref to parameters.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,0 @@
-*       @bpescato-amazon
-*       @VTWoods

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-.DS_Store

--- a/connection-coordinator/openapi.yaml
+++ b/connection-coordinator/openapi.yaml
@@ -61,5 +61,26 @@ components:
     MacSecKey:
       $ref: schemas/macseckey.yaml#/MacSecKey
   parameters:
-    $ref: parameters/_index.yaml#/parameters
-    
+    provider:
+      $ref: parameters/_index.yaml#/parameters/provider
+    environment:
+      $ref: parameters/_index.yaml#/parameters/environment
+    interconnect:
+      $ref: parameters/_index.yaml#/parameters/interconnect
+    channel:
+      $ref: parameters/_index.yaml#/parameters/channel
+    connection:
+      $ref: parameters/_index.yaml#/parameters/connection
+    feature:
+      $ref: parameters/_index.yaml#/parameters/feature
+    macSecKey:
+      $ref: parameters/_index.yaml#/parameters/macSecKey
+    alt:
+      $ref: parameters/_index.yaml#/parameters/alt
+    callback:
+      $ref: parameters/_index.yaml#/parameters/callback
+    prettyPrint:
+      $ref: parameters/_index.yaml#/parameters/prettyPrint
+    _.xgafv:
+      $ref: parameters/_index.yaml#/parameters/_.xgafv
+


### PR DESCRIPTION
Fix $ref to parameters.


Unfortunately you must pull in these files individually or the yaml file won't parse.

Exception in thread "main" org.openapitools.codegen.SpecValidationException: There were issues with the specification. The option can be disabled via validateSpec (Maven/Gradle) or --skip-validate-spec (CLI).
 | Error count: 1, Warning count: 0
Errors:
        -components.parameters.Parameter name $ref doesn't adhere to regular expression ^[a-zA-Z0-9\.\-_]+$

        at org.openapitools.codegen.config.CodegenConfigurator.toContext(CodegenConfigurator.java:718)
        at org.openapitools.codegen.config.CodegenConfigurator.toClientOptInput(CodegenConfigurator.java:745)
        at org.openapitools.codegen.cmd.Generate.execute(Generate.java:527)
        at org.openapitools.codegen.cmd.OpenApiGeneratorCommand.run(OpenApiGeneratorCommand.java:32)
        at org.openapitools.codegen.OpenAPIGenerator.main(OpenAPIGenerator.java:66)
