### PR TITLE
Add Case resource definitions to Transport Coordinator API.

### DIFF
--- a/connection-coordinator/openapi.yaml
+++ b/connection-coordinator/openapi.yaml
@@ -44,6 +44,16 @@ paths:
     $ref: paths/features.yaml#/AllFeatures
   /providers/{provider}/environments/{environment}/interconnects/{interconnect}/connections/{connection}/features/{feature}:
     $ref: paths/features.yaml#/OneFeature
+  /providers/{provider}/issues:
+    $ref: paths/issues.yaml#/AllIssues
+  /providers/{provider}/issues/{issue}:
+    $ref: paths/issues.yaml#/OneIssue
+  /providers/{provider}/issues/{issue}/Close:
+    $ref: paths/issues.yaml#/CloseIssue
+  /providers/{provider}/issues/{issue}/comments:
+    $ref: paths/issues.yaml#/ListComments
+  /providers/{provider}/issues/{issue}/AddComment:
+    $ref: paths/issues.yaml#/AddComment
 components:
   schemas:
     Provider:
@@ -60,6 +70,8 @@ components:
       $ref: schemas/feature.yaml#/Feature
     MacSecKey:
       $ref: schemas/macseckey.yaml#/MacSecKey
+    Issue:
+      $ref: schemas/issues.yaml#/Issue
   parameters:
     provider:
       $ref: parameters/_index.yaml#/parameters/provider
@@ -75,6 +87,8 @@ components:
       $ref: parameters/_index.yaml#/parameters/feature
     macSecKey:
       $ref: parameters/_index.yaml#/parameters/macSecKey
+    issue:
+      $ref: parameters/_index.yaml#/parameters/issue
     alt:
       $ref: parameters/_index.yaml#/parameters/alt
     callback:

--- a/connection-coordinator/parameters/_index.yaml
+++ b/connection-coordinator/parameters/_index.yaml
@@ -69,6 +69,16 @@ parameters:
       type: string
     style: simple
 
+  issue:
+    description: Resource ID segment making up resource `name`.
+    explode: false
+    in: path
+    name: issue
+    required: true
+    schema:
+      type: string
+    style: simple
+
   alt:
     description: Data format for response.
     explode: true

--- a/connection-coordinator/paths/issues.yaml
+++ b/connection-coordinator/paths/issues.yaml
@@ -1,0 +1,162 @@
+AllIssues:
+  get:
+    description: Lists Issues in a given project and location.
+    operationId: ListIssues
+    parameters:
+    - $ref: "../parameters/_index.yaml#/parameters/provider"
+    - description: 'Optional. The maximum number of issues to return. The service
+        may return fewer than
+
+        this value. If unspecified, at most 50 issues will be returned. The maximum
+
+        value is 1000; values above 1000 will be coerced to 1000.'
+      in: query
+      name: pageSize
+      schema:
+        format: int32
+        type: integer
+    - description: 'Optional. A page token, received from a previous `ListIssues`
+        call.
+
+        Provide this to retrieve the subsequent page.'
+      in: query
+      name: pageToken
+      schema:
+        type: string
+    responses:
+      default:
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/issues.yaml#/ListIssuesResponse"
+        description: Successful operation
+    security: []
+    tags:
+    - Issues
+  post:
+    description: Creates a new Issue in a given project and location.
+    operationId: CreateIssue
+    parameters:
+    - $ref: "../parameters/_index.yaml#/parameters/provider"
+    - description: 'Required. The ID to use for the issue, which will become the
+        final component of the issue''s resource name.'
+      in: query
+      name: issueId
+      required: true
+      schema:
+        type: string
+    requestBody:
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/issues.yaml#/Issue'
+      description: Required. The resource being created
+    responses:
+      default:
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/issues.yaml#/Issue'
+        description: Successful operation
+    security: []
+    tags:
+    - Issues
+OneIssue:
+  get:
+    description: Gets details of a single Issue.
+    operationId: GetIssue
+    parameters:
+    - $ref: "../parameters/_index.yaml#/parameters/provider"
+    - $ref: "../parameters/_index.yaml#/parameters/issue"
+    responses:
+      default:
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/issues.yaml#/Issue'
+        description: Successful operation
+    security: []
+    tags:
+    - Issues
+CloseIssue:
+  post:
+    description: Closes an Issue.
+    operationId: CloseIssue
+    parameters:
+    - $ref: "../parameters/_index.yaml#/parameters/provider"
+    - $ref: "../parameters/_index.yaml#/parameters/issue"
+    requestBody:
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/issues.yaml#/CloseIssueRequest'
+      description: The request body.
+    responses:
+      default:
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/issues.yaml#/Issue'
+        description: Successful operation
+    security: []
+    tags:
+    - Issues
+AddComment:
+  post:
+    description: Adds a comment to a Issue.
+    operationId: AddComment
+    parameters:
+    - $ref: "../parameters/_index.yaml#/parameters/provider"
+    - $ref: "../parameters/_index.yaml#/parameters/issue"
+    requestBody:
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/issues.yaml#/AddCommentRequest'
+      description: The request body.
+    responses:
+      default:
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/issues.yaml#/AddCommentResponse'
+        description: Successful operation
+    security: []
+    tags:
+    - Issues
+ListComments:
+  get:
+    description: Lists comments for a Issue.
+    operationId: ListComments
+    parameters:
+    - $ref: "../parameters/_index.yaml#/parameters/provider"
+    - $ref: "../parameters/_index.yaml#/parameters/issue"
+    - description: 'Optional. The maximum number of comments to return. The service
+        may return fewer than
+
+        this value. If unspecified, at most 50 comments will be returned. The
+
+        maximum value is 1000; values above 1000 will be coerced to 1000.'
+      in: query
+      name: pageSize
+      schema:
+        format: int32
+        type: integer
+    - description: 'Optional. A page token, received from a previous `ListComments`
+        call.
+
+        Provide this to retrieve the subsequent page.'
+      in: query
+      name: pageToken
+      schema:
+        type: string
+    responses:
+      default:
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/issues.yaml#/ListCommentsResponse'
+        description: Successful operation
+    security: []
+    tags:
+    - Issues

--- a/connection-coordinator/schemas/issues.yaml
+++ b/connection-coordinator/schemas/issues.yaml
@@ -1,0 +1,289 @@
+State:
+  enum:
+  - STATE_UNSPECIFIED
+  - STATE_OPEN
+  - STATE_IN_PROGRESS
+  - STATE_ACTION_REQUIRED
+  - STATE_CLOSED
+  type: string
+  x-google-enum-descriptions:
+  - Unspecified state.
+  - The issue is pending triage.
+  - The issue is being actively worked on.
+  - The issue requires action from the requesting provider.
+  - The issue has been resolved.
+Priority:
+  enum:
+  - PRIORITY_UNSPECIFIED
+  - PRIORITY_P0
+  - PRIORITY_P1
+  - PRIORITY_P2
+  - PRIORITY_P3
+  - PRIORITY_P4
+  type: string
+  x-google-enum-descriptions:
+  - Unspecified priority.
+  - Highest priority.
+  - High priority.
+  - Medium priority.
+  - Low priority.
+  - Lowest priority.
+IssueContext:
+  enum:
+  - ISSUE_CONTEXT_UNSPECIFIED
+  - ISSUE_CONTEXT_CONNECTION_ISSUE
+  - ISSUE_CONTEXT_INTERCONNECT_ISSUE
+  type: string
+  x-google-enum-descriptions:
+  - 'Unspecified context, when set the caller may create an issue with arbirary
+
+    content and set context as needed.'
+  - 'The issue is related to a connection issue.
+
+
+    The following context is required: ConnectionContext'
+  - 'The issue is related to an interconnect issue.
+
+
+    The following context is required: InterconnectContext'
+ChannelContext:
+  description: A channel experiencing an issue and any relevant context associated
+    with it.
+  properties:
+    channel:
+      description: Required. Channel experiencing issues.
+      type: string
+  required:
+  - channel
+  type: object
+
+ConnectionContext:
+  description: 'A connection experiencing an issue and any relevant context associated
+    with
+
+    it.'
+  properties:
+    connection:
+      description: Required. Connection experiencing issues.
+      type: string
+  required:
+  - connection
+  type: object
+FeatureContext:
+  description: A feature experiencing an issue and any relevant context associated
+    with it.
+  properties:
+    feature:
+      description: Required. Feature experincing issues.
+      type: string
+  required:
+  - feature
+  type: object
+InterconnectContext:
+  description: 'An interconnect experiencing an issue and any relevant context
+    associated
+
+    with it.'
+  properties:
+    interconnect:
+      description: Required. Interconnect experiencing issues.
+      type: string
+  required:
+  - interconnect
+  type: object
+Issue:
+  description: 'An issue as expressed by a remote provider related to shared resources
+    with
+
+    the local provider.
+
+
+    Outside of the standard issue fields (body, title, etc), context objects are
+
+    included to allow callers to provide explicit resources associated with the
+
+    issue.  These resources may have additional metadata associated with them
+    to
+
+    further describe the issue.
+
+
+    To further standardize the information within a request, the IssueContext
+
+    describes a preset issue type that a provider must be capable of handling.
+
+    This issue type may require specific context be provided in the request.  If
+
+    so, the provider may reject the request if that context is not provided.'
+  properties:
+    body:
+      description: Required. Issue body.  Core content of the issue.
+      type: string
+    channelContexts:
+      description: Optional. Context associated with channels implicated by this
+        issue.
+      items:
+        $ref: '../schemas/issues.yaml#/ChannelContext'
+      type: array
+    connectionContexts:
+      description: Optional. Context associated with connections implicated by
+        this issue.
+      items:
+        $ref: '../schemas/issues.yaml#/ConnectionContext'
+      type: array
+    createTime:
+      description: Output only. The time the issue was created.
+      format: date-time
+      readOnly: true
+      type: string
+    featureContexts:
+      description: Optional. Context associated with features implicated by this
+        issue.
+      items:
+        $ref: '../schemas/issues.yaml#/FeatureContext'
+      type: array
+    interconnectContexts:
+      description: Optional. Context associated with interconnects implicated
+        by this issue.
+      items:
+        $ref: '../schemas/issues.yaml#/InterconnectContext'
+      type: array
+    issueContext:
+      allOf:
+      - $ref: '../schemas/issues.yaml#/IssueContext'
+      description: 'Optional. The type of issue associated with resources defined
+        within the connection
+
+        coordinator.'
+    localIssueId:
+      description: 'Output only. Opaque identifier for the local provider.  This
+        identifier allows you to
+
+        interact with the local providers official support API if desired.'
+      readOnly: true
+      type: string
+    name:
+      description: 'Identifier. The name of the issue resource.
+
+        Format:
+
+        projects/{project}/locations/{location}/providers/{provider}/issues/{issue}'
+      type: string
+      x-google-identifier: true
+    priority:
+      allOf:
+      - $ref: '../schemas/issues.yaml#/Priority'
+      description: Optional. The priority of the issue.
+    remoteContactEmail:
+      description: 'Optional. The email address to send all email communications
+        to in the remote
+
+        provider.'
+      type: string
+    remoteIssueId:
+      description: 'Optional. Opaque identifier for the remote provider.  This
+        identifier allows you to
+
+        interact with the remote providers official support API if desired.'
+      type: string
+    state:
+      allOf:
+      - $ref: '../schemas/issues.yaml#/State'
+      description: Output only. The state of the issue.
+      readOnly: true
+    title:
+      description: Required. Issue title.  A single line that summarizes the issue.
+      type: string
+  required:
+  - title
+  - body
+  type: object
+Comment:
+  description: 'A comment on a issue.
+
+
+    Typically comments are a pass through from this API to the remote provider''s
+
+    core support APIs.  Therefore, these are not formal resources represented
+
+    within this API and store no state unique to the connection coordinator
+
+    specification.'
+  properties:
+    body:
+      description: Required. The body of the comment.
+      type: string
+    createTime:
+      description: Output only. The time the comment was created.
+      format: date-time
+      readOnly: true
+      type: string
+    displayName:
+      description: Output only. The display name of the commenter.
+      readOnly: true
+      type: string
+    localCommentId:
+      description: 'Output only. Opaque identifier for the local comment.  This
+        identifier allows the caller
+
+        to interact with the local providers official support API if desired.'
+      readOnly: true
+      type: string
+  required:
+  - body
+  type: object
+AddCommentRequest:
+  description: Add a comment to an issue.
+  properties:
+    comment:
+      allOf:
+      - $ref: '../schemas/issues.yaml#/Comment'
+      description: Required. The comment to add.
+  required:
+  - comment
+  type: object
+AddCommentResponse:
+  description: Results of adding a comment to an issue.
+  properties:
+    comment:
+      allOf:
+      - $ref: '../schemas/issues.yaml#/Comment'
+      description: The comment that was added.
+  type: object
+CloseIssueRequest:
+  description: Request to close an issue.
+  type: object
+CloseIssueResponse:
+  description: Results of closing an issue.
+  type: object
+ListCommentsResponse:
+  description: 'List issue comments response body. By default, comments are sorted
+    by create_time in descending order.'
+  properties:
+    comments:
+      description: The list of Comments
+      items:
+        $ref: '../schemas/issues.yaml#/Comment'
+      type: array
+    nextPageToken:
+      description: 'A token that can be sent as `page_token` to retrieve the next
+        page.
+
+        If this field is omitted, there are no subsequent pages.'
+      type: string
+  type: object
+ListIssuesResponse:
+  description: List of issues response body.
+  properties:
+    issues:
+      description: The list of Issue.
+      items:
+        $ref: '../schemas/issues.yaml#/Issue'
+      type: array
+    nextPageToken:
+      description: 'A token that can be sent as `page_token` to retrieve the next
+        page.
+
+        If this field is omitted, there are no subsequent pages.'
+      type: string
+  type: object


### PR DESCRIPTION
Add Case resource definitions to Transport Coordinator API

This change introduces the OpenAPI specifications for the new "Case" resource within the Transport Coordinator API. It includes definitions for listing, creating, and getting individual cases.
