### PR TITLE
Update operationIds for MACsec key paths.

### DIFF
--- a/connection-coordinator/paths/macseckeys.yaml
+++ b/connection-coordinator/paths/macseckeys.yaml
@@ -1,7 +1,7 @@
 AllMacSecKeys:
   post:
     description: Create a new MACsec key on the channel
-    operationId: GetMacSecKey
+    operationId: CreateMacSecKey
     parameters:
     - $ref: "../parameters/_index.yaml#/parameters/provider"
     - $ref: "../parameters/_index.yaml#/parameters/environment"
@@ -40,7 +40,7 @@ AllMacSecKeys:
     - MacSecKey
   get:
     description: List all the MACsec keys associated with the channel
-    operationId: GetMacSecKey
+    operationId: ListMacSecKey
     parameters:
     - $ref: "../parameters/_index.yaml#/parameters/provider"
     - $ref: "../parameters/_index.yaml#/parameters/environment"


### PR DESCRIPTION
Update operationIds for MACsec key paths.

Renames the `post` operationId from `GetMacSecKey` to `CreateMacSecKey` and the `get` operationId from `GetMacSecKey` to `ListMacSecKey` to better reflect their actions.
