### PR TITLE
fix: corrected typos in connection-coordinator schema descriptions

### DIFF
--- a/connection-coordinator/docs/ConnectionCoordinatorAPI.md
+++ b/connection-coordinator/docs/ConnectionCoordinatorAPI.md
@@ -52,7 +52,7 @@ Overall, this `CreateConnection` operation needs to determine at least the follo
 - Environment
 - Bandwidth
 
-#### Rmote CSP Account ID
+#### Remote CSP Account ID
 
 When creating the connection, the customer must supply a means of identifying which account on the other CSP they intend to connect.  In the case of AWS, this would be the account number, and in the case of GCP, this would be the Project Name.  This is used to ensure that only a single destination account can accept the details of this specific connection when it is time for the later confirmation step.
 

--- a/connection-coordinator/schemas/issues.yaml
+++ b/connection-coordinator/schemas/issues.yaml
@@ -35,7 +35,7 @@ IssueContext:
   - ISSUE_CONTEXT_INTERCONNECT_ISSUE
   type: string
   x-google-enum-descriptions:
-  - 'Unspecified context, when set the caller may create an issue with arbirary
+  - 'Unspecified context, when set the caller may create an issue with arbitrary
 
     content and set context as needed.'
   - 'The issue is related to a connection issue.
@@ -74,7 +74,7 @@ FeatureContext:
     with it.
   properties:
     feature:
-      description: Required. Feature experincing issues.
+      description: Required. Feature experiencing issues.
       type: string
   required:
   - feature

--- a/connection-coordinator/schemas/macseckey.yaml
+++ b/connection-coordinator/schemas/macseckey.yaml
@@ -16,7 +16,7 @@ MacSecKey:
     active: true
   properties:
     name:
-      description: Identifier. A unique identifer for the macSecKey resource.
+      description: Identifier. A unique identifier for the macSecKey resource.
       type: string
     cak:
       description: MACsec protocol CAK.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Corrected arbirary to arbitrary
- Corrected experincing to experiencing
- Corrected indentifer to identifier

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
