### PR TITLE
Update example resource names to reflect realistic names

### DIFF
--- a/connection-coordinator/paths/macseckeys.yaml
+++ b/connection-coordinator/paths/macseckeys.yaml
@@ -21,7 +21,7 @@ AllMacSecKeys:
       content:
         application/json:
           example:
-            name: name
+            name: providers/my-provider/environments/my-environment/interconnects/my-interconnect/channels/my-channel/macSecKeys/my-macSecKey
             cak: MACsec CAK
             ckn: MACsec CKN 
           schema:

--- a/connection-coordinator/schemas/channel.yaml
+++ b/connection-coordinator/schemas/channel.yaml
@@ -17,7 +17,7 @@ Channel:
     demarc: demarc
     crossConnectManagerProvider: crossConnectManagerProvider
     channelMemberSizeGbps: 6
-    name: name
+    name: providers/my-provider/environments/my-environment/interconnects/my-interconnect/channels/my-channel
     adminState: ""
     macsecManagerProvider: macsecManagerProvider
     aggregateChannelSizeGbps: 0
@@ -82,7 +82,7 @@ ListChannelsResponse:
     - demarc: demarc
       crossConnectManagerProvider: crossConnectManagerProvider
       channelMemberSizeGbps: 6
-      name: name
+      name: providers/my-provider/environments/my-environment/interconnects/my-interconnect/channels/my-channel
       adminState: ""
       macsecManagerProvider: macsecManagerProvider
       aggregateChannelSizeGbps: 0
@@ -90,7 +90,7 @@ ListChannelsResponse:
     - demarc: demarc
       crossConnectManagerProvider: crossConnectManagerProvider
       channelMemberSizeGbps: 6
-      name: name
+      name: providers/my-provider/environments/my-environment/interconnects/my-interconnect/channels/my-channel
       adminState: ""
       macsecManagerProvider: macsecManagerProvider
       aggregateChannelSizeGbps: 0

--- a/connection-coordinator/schemas/connection.yaml
+++ b/connection-coordinator/schemas/connection.yaml
@@ -15,7 +15,7 @@ Connection:
     5. When deleted, the server provider is responsible for invalidating the key
         material associated with the connection to avoid accidental reuse.
   example:
-    name: name
+    name: providers/my-provider/environments/my-environment/interconnects/my-interconnect/connections/my-connection
     adminState: ""
     activationKey: activationKey
     verificationState: ""
@@ -243,12 +243,12 @@ ListConnectionsResponse:
   example:
     nextPageToken: nextPageToken
     connections:
-    - name: name
+    - name: providers/my-provider/environments/my-environment/interconnects/my-interconnect/connections/my-connection
       adminState: ""
       activationKey: activationKey
       verificationState: ""
       bandwidthMbps: 0
-    - name: name
+    - name: providers/my-provider/environments/my-environment/interconnects/my-interconnect/connections/my-connection
       adminState: ""
       activationKey: activationKey
       verificationState: ""
@@ -278,10 +278,10 @@ GenerateFeatureGuidanceResponse:
     featureGuidance:
     - l3BaseGuidance: ""
       featureType: ""
-      channel: channel
+      channel: providers/my-provider/environments/my-environment/interconnects/my-interconnect/channels/my-channel
     - l3BaseGuidance: ""
       featureType: ""
-      channel: channel
+      channel: providers/my-provider/environments/my-environment/interconnects/my-interconnect/channels/my-channel
   properties:
     featureGuidance:
       description: |-

--- a/connection-coordinator/schemas/environment.yaml
+++ b/connection-coordinator/schemas/environment.yaml
@@ -22,7 +22,7 @@ Environment:
     supportedFeatures:
     - FEATURE_TYPE_L3_BASE
     - FEATURE_TYPE_L3_BASE
-    name: name
+    name: providers/my-provider/environments/my-environment
     environmentVisibility: ""
     supportedConnectionSizeMbps:
     - 0
@@ -124,7 +124,7 @@ ListEnvironmentsResponse:
       supportedFeatures:
       - FEATURE_TYPE_L3_BASE
       - FEATURE_TYPE_L3_BASE
-      name: name
+      name: providers/my-provider/environments/my-environment
       environmentVisibility: ""
       supportedConnectionSizeMbps:
       - 0

--- a/connection-coordinator/schemas/feature.yaml
+++ b/connection-coordinator/schemas/feature.yaml
@@ -3,8 +3,8 @@ Feature:
     Feature resources describe all configuration per-channel that is required to
     enable a feature for a specified connection.
   example:
-    name: name
-    channel: channel
+    name: providers/my-provider/environments/my-environment/interconnects/my-interconnect/connections/my-connection/features/my-feature
+    channel: providers/my-provider/environments/my-environment/interconnects/my-interconnect/channels/my-channel
     featureConfig: ""
     provisioningState: ""
   properties:
@@ -127,12 +127,12 @@ ListFeaturesResponse:
   description: Response for obtaining multiple feature resources.
   example:
     features:
-    - name: name
-      channel: channel
+    - name: providers/my-provider/environments/my-environment/interconnects/my-interconnect/connections/my-connection/features/my-feature
+      channel: providers/my-provider/environments/my-environment/interconnects/my-interconnect/channels/my-channel
       featureConfig: ""
       provisioningState: ""
-    - name: name
-      channel: channel
+    - name: providers/my-provider/environments/my-environment/interconnects/my-interconnect/connections/my-connection/features/my-feature
+      channel: providers/my-provider/environments/my-environment/interconnects/my-interconnect/channels/my-channel
       featureConfig: ""
       provisioningState: ""
     nextPageToken: nextPageToken

--- a/connection-coordinator/schemas/interconnect.yaml
+++ b/connection-coordinator/schemas/interconnect.yaml
@@ -13,7 +13,7 @@ Interconnect:
     supportedFeatures:
     - FEATURE_TYPE_L3_BASE
     - FEATURE_TYPE_L3_BASE
-    name: name
+    name: providers/my-provider/environments/my-environment/interconnects/my-interconnect
     state: ""
     supportedConnectionSizeMbps:
     - 0
@@ -84,7 +84,7 @@ ListInterconnectsResponse:
     - supportedFeatures:
       - FEATURE_TYPE_L3_BASE
       - FEATURE_TYPE_L3_BASE
-      name: name
+      name: providers/my-provider/environments/my-environment/interconnects/my-interconnect
       state: ""
       supportedConnectionSizeMbps:
       - 0
@@ -93,7 +93,7 @@ ListInterconnectsResponse:
     - supportedFeatures:
       - FEATURE_TYPE_L3_BASE
       - FEATURE_TYPE_L3_BASE
-      name: name
+      name: providers/my-provider/environments/my-environment/interconnects/my-interconnect
       state: ""
       supportedConnectionSizeMbps:
       - 0

--- a/connection-coordinator/schemas/macseckey.yaml
+++ b/connection-coordinator/schemas/macseckey.yaml
@@ -9,7 +9,7 @@ MacSecKey:
     When creating the MacSecKey, the `startTime` on the created object MUST
     be set by the server to the current time when the request was accepted.
   example:
-    name: name
+    name: providers/my-provider/environments/my-environment/interconnects/my-interconnect/channels/my-channel/macSecKeys/my-macSecKey
     cak: MACsec CAK
     ckn: MACsec CKN
     startTime: 2000-01-23T04:56:07.000+00:00

--- a/connection-coordinator/schemas/provider.yaml
+++ b/connection-coordinator/schemas/provider.yaml
@@ -25,7 +25,7 @@ Provider:
     information about the server provider (such as display names).
   example:
     displayName: displayName
-    name: name
+    name: providers/my-provider
   properties:
     name:
       description: |-
@@ -51,9 +51,9 @@ ListProvidersResponse:
   example:
     providers:
     - displayName: displayName
-      name: name
+      name: providers/my-provider
     - displayName: displayName
-      name: name
+      name: providers/my-provider
     nextPageToken: nextPageToken
   properties:
     environments:


### PR DESCRIPTION
Update example resource names to reflect realistic names

The examples for resource names in various schemas and paths have been updated to reflect the standard resource name format (e.g., `providers/{provider}/environments/{environment}`).
