### PR TITLE
Update resource ID descriptions and add format specifications.

### DIFF
--- a/connection-coordinator/parameters/_index.yaml
+++ b/connection-coordinator/parameters/_index.yaml
@@ -1,6 +1,6 @@
 parameters:
   provider:
-    description: Resource ID segment making up resource `name`.
+    description: Resource ID segment making up resource `id`.
     explode: false
     in: path
     name: provider
@@ -10,7 +10,7 @@ parameters:
     style: simple
 
   environment:
-    description: Resource ID segment making up resource `name`.
+    description: Resource ID segment making up resource `id`.
     explode: false
     in: path
     name: environment
@@ -20,7 +20,7 @@ parameters:
     style: simple
 
   interconnect:
-    description: Resource ID segment making up resource `name`.
+    description: Resource ID segment making up resource `id`.
     explode: false
     in: path
     name: interconnect
@@ -30,7 +30,7 @@ parameters:
     style: simple
 
   channel:
-    description: Resource ID segment making up resource `name`.
+    description: Resource ID segment making up resource `id`.
     explode: false
     in: path
     name: channel
@@ -40,7 +40,7 @@ parameters:
     style: simple
 
   connection:
-    description: Resource ID segment making up resource `name`.
+    description: Resource ID segment making up resource `id`.
     explode: false
     in: path
     name: connection
@@ -50,7 +50,7 @@ parameters:
     style: simple
 
   feature:
-    description: Resource ID segment making up resource `name`.
+    description: Resource ID segment making up resource `id`.
     explode: false
     in: path
     name: feature
@@ -60,7 +60,7 @@ parameters:
     style: simple
 
   macSecKey:
-    description: Resource ID segment making up resource `name`.
+    description: Resource ID segment making up resource `id`.
     explode: false
     in: path
     name: macSecKey
@@ -70,7 +70,7 @@ parameters:
     style: simple
 
   issue:
-    description: Resource ID segment making up resource `name`.
+    description: Resource ID segment making up resource `id`.
     explode: false
     in: path
     name: issue

--- a/connection-coordinator/schemas/channel.yaml
+++ b/connection-coordinator/schemas/channel.yaml
@@ -24,7 +24,10 @@ Channel:
     obfuscatedDeviceId: obfuscatedDeviceId
   properties:
     name:
-      description: Identifier. Unique identifier for the Channel resource.
+      description: |-
+        Identifier. Unique identifier for the Channel resource.
+
+        Format: providers/{provider}/environments/{environment}/interconnects/{interconnect}/channels/{channel}
       type: string
     macsecManagerProvider:
       description: |-
@@ -32,6 +35,8 @@ Channel:
 
         This field must prevent the non-manager provider from calling Macsec
         APIs.
+
+        Format: providers/{provider}
       readOnly: true
       type: string
     crossConnectManagerProvider:
@@ -39,6 +44,8 @@ Channel:
         Output only. The URI of the provider responsible for managing physical crossconnects.  This
         includes cross connect costs and any troubleshooting requests to the vendor
         providing the cross connect.
+
+        Format: providers/{provider}
       readOnly: true
       type: string
     aggregateChannelSizeGbps:

--- a/connection-coordinator/schemas/connection.yaml
+++ b/connection-coordinator/schemas/connection.yaml
@@ -22,7 +22,10 @@ Connection:
     bandwidthMbps: 0
   properties:
     name:
-      description: Identifier. A unique identifier for the connection resource.
+      description: |-
+        Identifier. A unique identifier for the connection resource.
+
+        Format: providers/{provider}/environments/{environment}/interconnects/{interconnect}/connections/{connection}
       type: string
     activationKey:
       description: Identifier. A activation key associated with the connection.
@@ -63,7 +66,10 @@ FeatureGuidance:
       - $ref: "feature.yaml#/FeatureType"
       description: The feature type associated with this guidance.
     channel:
-      description: Relative URI of the Channel this guidance applies to.
+      description: |-
+        Relative URI of the Channel this guidance applies to.
+
+        Format: providers/{provider}/environments/{environment}/interconnects/{interconnect}/channels/{channel}
       type: string
     l3BaseGuidance:
       allOf:

--- a/connection-coordinator/schemas/environment.yaml
+++ b/connection-coordinator/schemas/environment.yaml
@@ -29,7 +29,10 @@ Environment:
     - 0
   properties:
     name:
-      description: Identifier. Unique identifier for an Environment resource.
+      description: |-
+        Identifier. Unique identifier for an Environment resource.
+
+        Format: providers/{provider}/environments/{environment}
       type: string
     providerSites:
       description: |-
@@ -87,7 +90,10 @@ ProviderSites:
     displayName: displayName
   properties:
     providerId:
-      description: Which provider this site data is associated with.
+      description: |-
+        Which provider this site data is associated with.
+
+        Format: providers/{provider}
       type: string
     site:
       description: A provider specific site name (e.g. us-east4).

--- a/connection-coordinator/schemas/feature.yaml
+++ b/connection-coordinator/schemas/feature.yaml
@@ -9,7 +9,10 @@ Feature:
     provisioningState: ""
   properties:
     name:
-      description: Identifier. A unique identifier for the feature resource.
+      description: |-
+        Identifier. A unique identifier for the feature resource.
+
+        Format: providers/{provider}/environments/{environment}/interconnects/{interconnect}/connections/{connection}/features/{feature}
       type: string
     channel:
       description: |-
@@ -20,6 +23,8 @@ Feature:
         that is a child of the parent interconnect resource. For example a
         connection that is a child of an interconnect with 4 channels will have 4
         child features, each associated with a different channel.
+
+        Format: providers/{provider}/environments/{environment}/interconnects/{interconnect}/channels/{channel}
       type: string
     featureConfig:
       allOf:
@@ -110,6 +115,8 @@ ProviderBgpConfig:
       description: |-
         Required. The resource name of the provider that this BGP configuration is
         associated with.
+
+        Format: providers/{provider}
       type: string
     asn:
       description: Required. The ASN associated with the provider.

--- a/connection-coordinator/schemas/interconnect.yaml
+++ b/connection-coordinator/schemas/interconnect.yaml
@@ -21,7 +21,10 @@ Interconnect:
     maxBandwidthMbps: 6
   properties:
     name:
-      description: Identifier. Unique identifier for the Interconnect resource.
+      description: |-
+        Identifier. Unique identifier for the Interconnect resource.
+
+        Format: providers/{provider}/environments/{environment}/interconnects/{interconnect}
       type: string
     supportedConnectionSizeMbps:
       description: |-

--- a/connection-coordinator/schemas/issues.yaml
+++ b/connection-coordinator/schemas/issues.yaml
@@ -51,7 +51,10 @@ ChannelContext:
     with it.
   properties:
     channel:
-      description: Required. Channel experiencing issues.
+      description: |-
+        Required. Channel experiencing issues.
+
+        Format: providers/{provider}/environments/{environment}/interconnects/{interconnect}/channels/{channel}
       type: string
   required:
   - channel
@@ -64,7 +67,10 @@ ConnectionContext:
     it.'
   properties:
     connection:
-      description: Required. Connection experiencing issues.
+      description: |-
+        Required. Connection experiencing issues.
+
+        Format: providers/{provider}/environments/{environment}/interconnects/{interconnect}/connections/{connection}
       type: string
   required:
   - connection
@@ -74,7 +80,10 @@ FeatureContext:
     with it.
   properties:
     feature:
-      description: Required. Feature experiencing issues.
+      description: |-
+        Required. Feature experiencing issues.
+
+        Format: providers/{provider}/environments/{environment}/interconnects/{interconnect}/connections/{connection}/features/{feature}
       type: string
   required:
   - feature
@@ -86,7 +95,10 @@ InterconnectContext:
     with it.'
   properties:
     interconnect:
-      description: Required. Interconnect experiencing issues.
+      description: |-
+        Required. Interconnect experiencing issues.
+
+        Format: providers/{provider}/environments/{environment}/interconnects/{interconnect}
       type: string
   required:
   - interconnect
@@ -163,11 +175,10 @@ Issue:
       readOnly: true
       type: string
     name:
-      description: 'Identifier. The name of the issue resource.
+      description: |-
+        Identifier. The name of the issue resource.
 
-        Format:
-
-        projects/{project}/locations/{location}/providers/{provider}/issues/{issue}'
+        Format: providers/{provider}/issues/{issue}
       type: string
       x-google-identifier: true
     priority:

--- a/connection-coordinator/schemas/macseckey.yaml
+++ b/connection-coordinator/schemas/macseckey.yaml
@@ -16,7 +16,10 @@ MacSecKey:
     active: true
   properties:
     name:
-      description: Identifier. A unique identifier for the macSecKey resource.
+      description: |-
+        Identifier. A unique identifier for the macSecKey resource.
+
+        Format: providers/{provider}/environments/{environment}/interconnects/{interconnect}/channels/{channel}/macSecKeys/{macSecKey}
       type: string
     cak:
       description: MACsec protocol CAK.

--- a/connection-coordinator/schemas/provider.yaml
+++ b/connection-coordinator/schemas/provider.yaml
@@ -36,6 +36,8 @@ Provider:
         opensource project, that uniquely identifies them.  When accessing a remote
         cloud connectivity server, the provider will use their provider ID to
         request and create resources within the remote server.
+
+        Format: providers/{provider}
       type: string
     displayName:
       description: |-


### PR DESCRIPTION
Update resource ID descriptions and add format specifications.

This change updates the descriptions of path parameters to indicate they form a resource "id" instead of "name". Additionally, explicit "Format:" strings are added to resource name fields within the schemas to clearly define the expected URI structure for various resources.
