### PR TITLE
Deprecate old notification APIs and update activation key handling.

### DIFF
--- a/connection-coordinator/paths/channels.yaml
+++ b/connection-coordinator/paths/channels.yaml
@@ -64,6 +64,10 @@ NotifyMaintenance:
     description: |-
       Notify a remote provider that maintenance events associated with a channel
       have been modified.
+
+      The receiving provider must refresh the specified channel resource
+      immediately after receiving this notification to ensure their local state
+      is consistent with the server provider.
     operationId: NotifyMaintenance
     parameters:
     - $ref: "../parameters/_index.yaml#/parameters/provider"

--- a/connection-coordinator/paths/connections.yaml
+++ b/connection-coordinator/paths/connections.yaml
@@ -208,6 +208,10 @@ NotifyConnectionStatus:
       2) A notification when an existing channel transitions from FINALIZED
           to PENDING.  This happens when features change and need finalization.
       3) A notification when a channel is FINALIZED after a feature change.
+
+      The receiving provider must refresh the specified connection resource
+      immediately after receiving this notification to ensure their local state
+      is consistent with the server provider.
     operationId: NotifyConnectionStatus
     parameters:
     - $ref: "../parameters/_index.yaml#/parameters/provider"

--- a/connection-coordinator/schemas/channel.yaml
+++ b/connection-coordinator/schemas/channel.yaml
@@ -120,19 +120,12 @@ NotifyMaintenanceRequest:
   description: |-
     A notification from a remote provider that a maintenance has been updated on
     a channel.
-  example:
-    events:
-    - maintenanceId: maintenanceId
-      startTime: 2000-01-23T04:56:07.000+00:00
-      endTime: 2000-01-23T04:56:07.000+00:00
-    - maintenanceId: maintenanceId
-      startTime: 2000-01-23T04:56:07.000+00:00
-      endTime: 2000-01-23T04:56:07.000+00:00
   properties:
     events:
       description: |-
         All maintenance events associated with the channel. At the time of sending
         the notification.
+      deprecated: true
       items:
         $ref: "#/MaintenanceEvent"
       type: array

--- a/connection-coordinator/schemas/connection.yaml
+++ b/connection-coordinator/schemas/connection.yaml
@@ -179,12 +179,10 @@ ASNRange:
   properties:
     start:
       description: First ASN (inclusive).
-      format: int32
-      type: integer
+      type: uint32
     stop:
       description: Last ASN (inclusive).
-      format: int32
-      type: integer
+      type: uint32
   type: object
 
 SubnetGuidance:

--- a/connection-coordinator/schemas/environment.yaml
+++ b/connection-coordinator/schemas/environment.yaml
@@ -168,14 +168,22 @@ ListEnvironmentsResponse:
 ConfirmActivationKeyRequest:
   description: |-
     Request to confirm the validity of a activation key provided by a remote
-    provider.
+    provider. The key should be provided in the `encodedKey` field as a base64
+    encoded string.
   example:
-    key: ""
+    encodedKey: ""
   properties:
     key:
       allOf:
       - $ref: "#/ActivationKey"
-      description: Activation key to be confirmed.
+      description: |-
+        DEPRECATED: Use `encodedKey` instead.
+        Activation key to be confirmed.
+      deprecated: true
+    encodedKey:
+      type: string
+      format: byte
+      description: Base64 encoded ActivationKey to be confirmed.
   type: object
 
 ActivationKey:

--- a/connection-coordinator/schemas/feature.yaml
+++ b/connection-coordinator/schemas/feature.yaml
@@ -120,8 +120,7 @@ ProviderBgpConfig:
       type: string
     asn:
       description: Required. The ASN associated with the provider.
-      format: int32
-      type: integer
+      type: uint32
     hostIpv4:
       description: Required. IPv4 address hosting BGP session for provider.
       type: string


### PR DESCRIPTION
Deprecate old notification APIs and update activation key handling.

Marked NotifyMaintenance and NotifyConnectionStatus operations as deprecated. In ConfirmActivationKeyRequest, deprecated the 'key' field and added 'encodedKey' for base64 encoded activation keys. Changed the format of the 'asn' field in Provider from int32 to uint32.
