### PR TITLE
add channelAdminState to FeatureGuidance 

### DIFF
--- a/connection-coordinator/schemas/connection.yaml
+++ b/connection-coordinator/schemas/connection.yaml
@@ -60,6 +60,7 @@ FeatureGuidance:
     l3BaseGuidance: ""
     featureType: ""
     channel: channel
+    channelAdminState: ""
   properties:
     featureType:
       allOf:
@@ -71,6 +72,11 @@ FeatureGuidance:
 
         Format: providers/{provider}/environments/{environment}/interconnects/{interconnect}/channels/{channel}
       type: string
+    channelAdminState:
+      allOf:
+      - $ref: common.yaml#/AdminState
+      description: Output only. The administrative status of the channel resource.
+      readOnly: true
     l3BaseGuidance:
       allOf:
       - $ref: "#/L3BaseGuidance"
@@ -283,9 +289,11 @@ GenerateFeatureGuidanceResponse:
     - l3BaseGuidance: ""
       featureType: ""
       channel: providers/my-provider/environments/my-environment/interconnects/my-interconnect/channels/my-channel
+      channelAdminState: ""
     - l3BaseGuidance: ""
       featureType: ""
       channel: providers/my-provider/environments/my-environment/interconnects/my-interconnect/channels/my-channel
+      channelAdminState: ""
   properties:
     featureGuidance:
       description: |-


### PR DESCRIPTION
This allows a provider to specify the current AdminState of a channel from its perspective when the active cloud is requesting guidance. 

By doing this the active negotiator can make a decision on whether to attempt provisioning based on the channel state. This removes the need for the active negotiator to make n Get calls for the n channels in the guidance just to deduce the AdminState of the channel. 

In the future if more data from the Channel was desired, then it may make point to increase the # of back and forths to decrease data duplication, but this serves the purpose for now. 
