### PR TITLE
Add RotateMacSecKey API to notify channel owner to rotate MACsec keys

### DIFF
--- a/connection-coordinator/docs/Protocols.md
+++ b/connection-coordinator/docs/Protocols.md
@@ -493,6 +493,14 @@ safest option to avoid ever sending unencrypted traffic. Also, because each key
 is completely independent of one another, we are often able to simply “fail
 forward” and skip directly past a failed key rather than trying to move back.
 
+### **Requesting a Key Rotation**
+
+If the non-owner provider determines that a key rotation is needed (e.g., due
+to a security concern or a compliance requirement), they may call
+**RequestMacSecKeyRotation** on the channel owner, optionally providing a
+reason. Upon receiving this request, the channel owner should initiate the
+standard rotation protocol described above.
+
 ## **Confused Deputy Resolution \[WIP\]**
 
 In order to ensure that customer impacting actions—specifically

--- a/connection-coordinator/openapi.yaml
+++ b/connection-coordinator/openapi.yaml
@@ -26,8 +26,8 @@ paths:
     $ref: paths/channels.yaml#/OneChannel
   /providers/{provider}/environments/{environment}/interconnects/{interconnect}/channels/{channel}/NotifyMaintenance:
     $ref: paths/channels.yaml#/NotifyMaintenance
-  /providers/{provider}/environments/{environment}/interconnects/{interconnect}/channels/{channel}/RotateMacSecKey:
-    $ref: paths/channels.yaml#/RotateMacSecKey
+  /providers/{provider}/environments/{environment}/interconnects/{interconnect}/channels/{channel}/RequestMacSecKeyRotation:
+    $ref: paths/channels.yaml#/RequestMacSecKeyRotation
   /providers/{provider}/environments/{environment}/interconnects/{interconnect}/channels/{channel}/maintenanceEvents:
     $ref: paths/channels.yaml#/GetMaintenanceEvents
   /providers/{provider}/environments/{environment}/interconnects/{interconnect}/channels/{channel}/macSecKeys:

--- a/connection-coordinator/openapi.yaml
+++ b/connection-coordinator/openapi.yaml
@@ -26,6 +26,8 @@ paths:
     $ref: paths/channels.yaml#/OneChannel
   /providers/{provider}/environments/{environment}/interconnects/{interconnect}/channels/{channel}/NotifyMaintenance:
     $ref: paths/channels.yaml#/NotifyMaintenance
+  /providers/{provider}/environments/{environment}/interconnects/{interconnect}/channels/{channel}/RotateMacSecKey:
+    $ref: paths/channels.yaml#/RotateMacSecKey
   /providers/{provider}/environments/{environment}/interconnects/{interconnect}/channels/{channel}/maintenanceEvents:
     $ref: paths/channels.yaml#/GetMaintenanceEvents
   /providers/{provider}/environments/{environment}/interconnects/{interconnect}/channels/{channel}/macSecKeys:

--- a/connection-coordinator/paths/channels.yaml
+++ b/connection-coordinator/paths/channels.yaml
@@ -109,16 +109,17 @@ GetMaintenanceEvents:
     security: []
     tags:
     - Channels
-RotateMacSecKey:
+RequestMacSecKeyRotation:
   post:
     description: |-
-      Notify the channel owner to rotate the MACsec key associated with
-      a channel.
+      Request the channel owner to perform a MACsec key rotation on a
+      channel.
 
-      Upon receiving this request, the channel owner must rotate the
-      MACsec key at their side and then update the MACsec key on the partner
-      side using the MACsec key management APIs.
-    operationId: RotateMacSecKey
+      This API allows the non-owner provider to indicate that a key
+      rotation is needed. Upon receiving this request, the channel owner
+      should rotate the MACsec key locally and then update the MACsec
+      key on the partner side using the MACsec key management APIs.
+    operationId: RequestMacSecKeyRotation
     parameters:
     - $ref: "../parameters/_index.yaml#/parameters/provider"
     - $ref: "../parameters/_index.yaml#/parameters/environment"
@@ -128,7 +129,7 @@ RotateMacSecKey:
       content:
         application/json:
           schema:
-            $ref: "../schemas/channel.yaml#/RotateMacSecKeyRequest"
+            $ref: "../schemas/channel.yaml#/MacSecKeyRotationRequest"
       description: The request body.
     responses:
       default:

--- a/connection-coordinator/paths/channels.yaml
+++ b/connection-coordinator/paths/channels.yaml
@@ -109,3 +109,34 @@ GetMaintenanceEvents:
     security: []
     tags:
     - Channels
+RotateMacSecKey:
+  post:
+    description: |-
+      Notify the channel owner to rotate the MACsec key associated with
+      a channel.
+
+      Upon receiving this request, the channel owner must rotate the
+      MACsec key at their side and then update the MACsec key on the partner
+      side using the MACsec key management APIs.
+    operationId: RotateMacSecKey
+    parameters:
+    - $ref: "../parameters/_index.yaml#/parameters/provider"
+    - $ref: "../parameters/_index.yaml#/parameters/environment"
+    - $ref: "../parameters/_index.yaml#/parameters/interconnect"
+    - $ref: "../parameters/_index.yaml#/parameters/channel"
+    requestBody:
+      content:
+        application/json:
+          schema:
+            $ref: "../schemas/channel.yaml#/RotateMacSecKeyRequest"
+      description: The request body.
+    responses:
+      default:
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/common.yaml#/Empty"
+        description: Successful operation
+    security: []
+    tags:
+    - Channels

--- a/connection-coordinator/schemas/channel.yaml
+++ b/connection-coordinator/schemas/channel.yaml
@@ -173,8 +173,13 @@ GetMaintenanceEventsResponse:
       type: array
   type: object
 
-RotateMacSecKeyRequest:
+MacSecKeyRotationRequest:
   description: |-
-    A request to notify the channel owner to rotate the MACsec key
-    associated with the channel.
+    A request from the non-owner provider to the channel owner to
+    perform a MACsec key rotation on the channel.
+  properties:
+    reason:
+      description: |-
+        The reason for requesting the MACsec key rotation.
+      type: string
   type: object

--- a/connection-coordinator/schemas/channel.yaml
+++ b/connection-coordinator/schemas/channel.yaml
@@ -172,3 +172,9 @@ GetMaintenanceEventsResponse:
         $ref: "#/MaintenanceEvent"
       type: array
   type: object
+
+RotateMacSecKeyRequest:
+  description: |-
+    A request to notify the channel owner to rotate the MACsec key
+    associated with the channel.
+  type: object


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Introduces a new POST endpoint at
/providers/{provider}/environments/{environment}/interconnects/{interconnect}/channels/{channel}/RotateMacSecKey
that allows a provider to notify the channel owner to rotate the MACsec
key on a channel. Upon receiving this request, the channel owner must
rotate the key locally and then update the partner side using the
existing MACsec key management APIs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
