### PR TITLE
chore: add Google code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-*       @bpescato-amazon
-*       @VTWoods
+*       @bpescato-amazon @VTWoods @dkarwowski

--- a/governance/MAINTAINERS.md
+++ b/governance/MAINTAINERS.md
@@ -7,5 +7,5 @@
 
 ## Google
 1. Mike Woods (@vtwoods)
-2. Dave Karwowski
+2. Dave Karwowski (@dkarwowski)
 3. Ethan Hodges 


### PR DESCRIPTION
Adding myself as a codeowner for redundancy on Google reviews

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
