### PR TITLE
Add context to activationKey

### DIFF
--- a/connection-coordinator/schemas/environment.yaml
+++ b/connection-coordinator/schemas/environment.yaml
@@ -236,6 +236,15 @@ ActivationKey:
         Required. User supplied account id/number on the destination CSP.
         Receiving service MUST verify that the activation key was provided from an authorized user of this account.
       type: string
+    context:
+      description: |-
+        Optional. Arbitrary key-value pairs set by the key creator. This can be used to pass additional context or metadata.
+        Providers MAY enforce a maximum character or size limit for this field.
+      type: object
+      additionalProperties: true
+      example:
+        customKey1: "any value we want"
+        anotherKey: "etc"
   required:
   - connectionSizeMbps
   - destinationAccountId


### PR DESCRIPTION
*Issue #, if available:*
As discussed with Brian adding optional field "context"to activationKey which contains key value pairs that can be used to specify the Azure generated servicekey for a Customer connection

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
