### PR TITLE
Add UpdateFeature (PATCH) operation with updatable field

### DIFF
--- a/connection-coordinator/paths/features.yaml
+++ b/connection-coordinator/paths/features.yaml
@@ -138,3 +138,56 @@ OneFeature:
     security: []
     tags:
     - Features
+  patch:
+    description: |-
+      Update a specific feature's attributes.
+
+      Not all feature types support updates. If UpdateFeature is called on a
+      feature whose type does not support updates, or whose provider has
+      declared it non-updatable, the server must return 405 METHOD NOT ALLOWED.
+
+      When calling this API, the remote provider should update their local
+      feature state before requesting an update to the server provider resource.
+
+      Errors:
+        405: METHOD_NOT_ALLOWED. Returned when the feature type does not support
+        updates or the provider has declared the feature non-updatable.
+        409: CONFLICT. Returned when a server detects concurrent updates to the
+        resource.
+    operationId: UpdateFeature
+    parameters:
+    - $ref: "../parameters/_index.yaml#/parameters/provider"
+    - $ref: "../parameters/_index.yaml#/parameters/environment"
+    - $ref: "../parameters/_index.yaml#/parameters/interconnect"
+    - $ref: "../parameters/_index.yaml#/parameters/connection"
+    - $ref: "../parameters/_index.yaml#/parameters/feature"
+    - description: The list of fields to update.
+      explode: true
+      in: query
+      name: updateMask
+      required: false
+      schema:
+        format: fieldmask
+        pattern: "^(\\s*[^,\\s.]+(\\s*[,.]\\s*[^,\\s.]+)*)?$"
+        type: string
+      style: form
+    requestBody:
+      content:
+        application/json:
+          schema:
+            $ref: "../schemas/feature.yaml#/Feature"
+      description: Required. The feature to update.
+    responses:
+      default:
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/feature.yaml#/Feature"
+        description: Successful operation
+      "405":
+        description: |-
+          METHOD_NOT_ALLOWED. The feature type does not support updates or the
+          provider has declared the feature non-updatable.
+    security: []
+    tags:
+    - Features

--- a/connection-coordinator/schemas/feature.yaml
+++ b/connection-coordinator/schemas/feature.yaml
@@ -35,11 +35,25 @@ Feature:
       - $ref: "common.yaml#/ProvisioningState"
       description: Output only. The provisioning state of the feature.
       readOnly: true
+    updatable:
+      description: |-
+        Output only. Indicates whether the feature supports updates via the
+        UpdateFeature operation. Defaults to false if not present.
+
+        A provider may declare a feature as non-updatable even if the feature
+        type generally supports updates.
+      type: boolean
+      default: false
+      readOnly: true
   type: object
 
 FeatureType:
-  description: FEATURE_TYPE_L3_BASE - Primary feature used to connect Layer 3
-    traffic.
+  description: |-
+    The type of feature.
+
+    Each feature type documents whether it supports updates via UpdateFeature:
+    - FEATURE_TYPE_L3_BASE: NOT updatable. Primary feature used to connect
+      Layer 3 traffic.
   enum:
   - FEATURE_TYPE_L3_BASE
   type: string


### PR DESCRIPTION
- Add PATCH operation on Feature resource (UpdateFeature) following the same pattern as UpdateConnection: full Feature body + optional updateMask
- Add read-only 'updatable' boolean field to Feature schema (optional, defaults to false), allowing providers to declare update support
- Document 405 METHOD_NOT_ALLOWED response for non-updatable features
- Update FeatureType enum description to document updatability per type (FEATURE_TYPE_L3_BASE: NOT updatable)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
