### PR TITLE
Use OpenAPI-compatible schema for unsigned 32-bit ASN fields

### DIFF
--- a/connection-coordinator/schemas/connection.yaml
+++ b/connection-coordinator/schemas/connection.yaml
@@ -206,10 +206,16 @@ ASNRange:
   properties:
     start:
       description: First ASN (inclusive).
-      type: uint32
+      type: integer
+      format: int64
+      minimum: 0
+      maximum: 4294967295
     stop:
       description: Last ASN (inclusive).
-      type: uint32
+      type: integer
+      format: int64
+      minimum: 0
+      maximum: 4294967295
   type: object
 
 SubnetGuidance:

--- a/connection-coordinator/schemas/feature.yaml
+++ b/connection-coordinator/schemas/feature.yaml
@@ -120,7 +120,10 @@ ProviderBgpConfig:
       type: string
     asn:
       description: Required. The ASN associated with the provider.
-      type: uint32
+      type: integer
+      format: int64
+      minimum: 0
+      maximum: 4294967295
     hostIpv4:
       description: Required. IPv4 address hosting BGP session for provider.
       type: string


### PR DESCRIPTION
## Summary

Replaces non-standard `type: uint32` schema declarations with OpenAPI-compatible integer schemas for ASN fields.

## Changes

- Updated `ASNRange.start` and `ASNRange.stop` in `connection.yaml`
- Updated `ProviderBgpConfig.asn` in `feature.yaml`
- Represented unsigned 32-bit values as:
  - `type: integer`
  - `format: int64`
  - `minimum: 0`
  - `maximum: 4294967295`

## Rationale

OpenAPI 3.0 does not define `uint32` as a valid primitive type. Using `integer` with `int64` format and explicit bounds preserves the intended unsigned 32-bit range while remaining compatible with OpenAPI tooling.

## Validation

- Confirmed no remaining `uint32` references.
- Confirmed all 19 YAML files parse successfully.