### PR TITLE
chore: fix minor inconsistencies in API

### DIFF
--- a/connection-coordinator/schemas/connection.yaml
+++ b/connection-coordinator/schemas/connection.yaml
@@ -66,8 +66,7 @@ Connection:
       oneOf:
       - $ref: "#/EncodedKey"
       - $ref: "#/SourceConnectionName"
-        
-
+      type: object
   type: object
   
 FeatureGuidance:
@@ -330,7 +329,6 @@ GenerateFeatureGuidanceResponse:
         provisioned on.
       items:
         $ref: "#/FeatureGuidance"
-      readOnly: true
       type: array
   type: object
 
@@ -347,6 +345,7 @@ EncodedKey:
   properties:
     encodedKey:
       type: string
+  type: object
 
 SourceConnectionName:
   description: |-
@@ -355,3 +354,4 @@ SourceConnectionName:
   properties:
     sourceConnectionName:
       type: string
+  type: object

--- a/connection-coordinator/schemas/feature.yaml
+++ b/connection-coordinator/schemas/feature.yaml
@@ -108,8 +108,6 @@ L3BaseConfig:
       description: Shared MD5 password for BGP sessions.
       type: string
   required:
-    - ipv4Subnet
-    - ipv4SubnetPrefixLength
     - md5BgpPassword
     - mtuBytes
     - providerBgpConfigs
@@ -141,7 +139,6 @@ ProviderBgpConfig:
       type: string
   required:
     - asn
-    - hostIpv4
     - provider
   type: object
 

--- a/connection-coordinator/schemas/feature.yaml
+++ b/connection-coordinator/schemas/feature.yaml
@@ -54,6 +54,8 @@ FeatureConfig:
       allOf:
       - $ref: "#/L3BaseConfig"
       description: All configuration associated with the FEATURE_TYPE_L3_BASE
+  required:
+    - featureType
   type: object
 L3BaseConfig:
   description: All FEATURE_TYPE_L3_BASE configuration.
@@ -105,6 +107,13 @@ L3BaseConfig:
     md5BgpPassword:
       description: Shared MD5 password for BGP sessions.
       type: string
+  required:
+    - ipv4Subnet
+    - ipv4SubnetPrefixLength
+    - md5BgpPassword
+    - mtuBytes
+    - providerBgpConfigs
+    - vlanId
   type: object
 ProviderBgpConfig:
   description: |-
@@ -130,6 +139,10 @@ ProviderBgpConfig:
     hostIpv6:
       description: Optional. IPv6 address hosting BGP session for provider.
       type: string
+  required:
+    - asn
+    - hostIpv4
+    - provider
   type: object
 
 ListFeaturesResponse:

--- a/connection-coordinator/schemas/macseckey.yaml
+++ b/connection-coordinator/schemas/macseckey.yaml
@@ -40,6 +40,7 @@ MacSecKey:
         While `active=true`, this macSecKey cannot be deleted.
       type: boolean
       readOnly: true
+  type: object
 
 ListMacSecKeysResponse:
   description: Response for obtaining multiple MacSecKey resources

--- a/connection-coordinator/schemas/provider.yaml
+++ b/connection-coordinator/schemas/provider.yaml
@@ -41,10 +41,9 @@ Provider:
       type: string
     displayName:
       description: |-
-        Output only. Provider name suitable for display to end users.
+        Provider name suitable for display to end users.
 
         Example: Amazon Web Services, Google Cloud Platform, Microsoft Azure, etc
-      readOnly: true
       type: string
   type: object
 
@@ -58,7 +57,7 @@ ListProvidersResponse:
       name: providers/my-provider
     nextPageToken: nextPageToken
   properties:
-    environments:
+    providers:
       description: The providers known to the remote.
       items:
         $ref: "#/Provider"


### PR DESCRIPTION
* minimal set of required fields listed for features.
* remove readonly settings from responses.
* missing type on macsec keys.
* removing readonly from providers that have no post methods
* list providers should be a list of providers